### PR TITLE
electronic_signature: set timeout in conf returned by get_credentials

### DIFF
--- a/doc/en/CHANGELOG
+++ b/doc/en/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#PROCK-283 Set timeout conf in get_credentials
 * BUG#PROCK-127 Add a timeout for calls to signature service
 * OTH#00000 Update tests to Tryton 6.4
 * FEA#21484 Allow to bypass electronic signature process

--- a/doc/fr/CHANGELOG
+++ b/doc/fr/CHANGELOG
@@ -1,3 +1,4 @@
+* BUG#PROCK-283 Positionner le délai de connexion dans la configuration renvoyée dans get_credentials
 * BUG#PROCK-127 Ajouter un délai de connexion pour les appels aux services de signature
 * OTH#00000 Mise à jour des tests vers Tryton 6.4
 * FEA#21484 Possibilité de contourner le processus de signature électronique

--- a/signature.py
+++ b/signature.py
@@ -268,6 +268,11 @@ class Signature(Workflow, ModelSQL, ModelView):
         conf['url'] = (credential.provider_url
                 if credential else config_parser.get(provider, 'url'))
         conf['log'] = credential.log_execution if credential else False
+        if credential.configurations:
+            conf['timeout'] = credential.configurations[0].timeout
+        else:
+            conf['timeout'] = 10
+
         return conf, credential
 
     @classmethod

--- a/signature.py
+++ b/signature.py
@@ -268,10 +268,8 @@ class Signature(Workflow, ModelSQL, ModelView):
         conf['url'] = (credential.provider_url
                 if credential else config_parser.get(provider, 'url'))
         conf['log'] = credential.log_execution if credential else False
-        if credential.configurations:
-            conf['timeout'] = credential.configurations[0].timeout
-        else:
-            conf['timeout'] = 10
+        conf['timeout'] = credential.configurations[0].timeout if \
+            credential.configurations else 10
 
         return conf, credential
 


### PR DESCRIPTION
Fix #PROCK-283

Report => Coog -2.12

**Pas testable sans environnement Universign fonctionnel, donc sera testé un préprod chez GIE/UMGP**